### PR TITLE
Updated usage docs with renamed gradle task name.

### DIFF
--- a/src/main/docs/guide/usage.adoc
+++ b/src/main/docs/guide/usage.adoc
@@ -10,7 +10,7 @@ The Vue.js client app has been built using the Vue-CLI with the `webpack` templa
 
 [source, bash]
 ----
-./gradlew client:start
+./gradlew client:serve
 ----
 
 The client app's `build.gradle` defines other tasks to test and build the app using the scripts in `client/package.json`.


### PR DESCRIPTION
The task client:start is now named client:serve.